### PR TITLE
Fix video type lookup

### DIFF
--- a/vidhdr.py
+++ b/vidhdr.py
@@ -275,7 +275,7 @@ def what(fpath, buf=None):
 
 def test_ftyp(buf, fd):
     ftyp = buf[8:12].strip()
-    video_type = VIDEO_TYPES.get(ftyp, {})
+    video_type = VIDEO_TYPES.get(str(ftyp), {})
     return video_type.get('mime-type')
 
 tests.append(test_ftyp)


### PR DESCRIPTION
Docs say they want a byte stream but the doc string requires a string.
Failure occurs in test_ftype due to an attempt to index a dict with a byte_string.

Instead of requiring the user to read and then cast a video to string before calling vidhdr.what I'm proposing better to cast to string in test_ftype.